### PR TITLE
Fix code scanning alert no. 4: Unvalidated dynamic method call

### DIFF
--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -168,7 +168,7 @@ export class LibraryService extends BaseService {
   }
 
   async unwatch(id: string) {
-    if (this.watchers[id]) {
+    if (this.watchers.hasOwnProperty(id) && typeof this.watchers[id] === 'function') {
       await this.watchers[id]();
       delete this.watchers[id];
     }


### PR DESCRIPTION
Fixes [https://github.com/offsoc/immich/security/code-scanning/4](https://github.com/offsoc/immich/security/code-scanning/4)

To fix the problem, we need to ensure that the `id` used to access the `this.watchers` object is valid and corresponds to a function. We can achieve this by checking if the `id` exists in the `this.watchers` object and if the corresponding value is a function before invoking it.

1. Modify the `unwatch` method in `server/src/services/library.service.ts` to include validation checks.
2. Ensure that the `id` exists in the `this.watchers` object and that the corresponding value is a function before calling it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
